### PR TITLE
Retarget extension documentation URL

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -4,7 +4,7 @@
 	"author": [
 		"WikiWorks team"
 	],
-	"url": "https://www.mediawiki.org/wiki/Extension:PagePort",
+	"url": "https://github.com/WikiTeq/PagePort#readme",
 	"descriptionmsg": "pageport-desc",
 	"license-name": "MIT",
 	"requires": {


### PR DESCRIPTION
Instead of pointing to a missing page on MediaWiki.org, use the repository's documentation.