### PR TITLE
Initial 1.39 support

### DIFF
--- a/.github/workflows/mediawiki.yml
+++ b/.github/workflows/mediawiki.yml
@@ -13,14 +13,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - mw: 'REL1_35'
+          - mw: 'REL1_39'
             php: 7.4
-#          - mw: 'REL1_36'
-#            php: 7.4
-#          - mw: 'REL1_37'
-#            php: 7.4
-#          - mw: 'master'
-#            php: 7.4
     runs-on: ubuntu-latest
     steps:
       # check out the repository!

--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,7 @@
 		"ext-zip": "*"
 	},
 	"require-dev": {
-		"mediawiki/minus-x": "1.1.0",
-		"estahn/phpunit-json-assertions": "^3.0"
+		"mediawiki/minus-x": "1.1.0"
 	},
 	"scripts": {
 		"test": [

--- a/extension.json
+++ b/extension.json
@@ -8,7 +8,7 @@
 	"descriptionmsg": "pageport-desc",
 	"license-name": "MIT",
 	"requires": {
-		"MediaWiki": ">= 1.30.0"
+		"MediaWiki": ">= 1.39.0"
 	},
 	"type": "other",
 	"AutoloadClasses": {

--- a/includes/PagePort.php
+++ b/includes/PagePort.php
@@ -149,7 +149,7 @@ class PagePort {
 		$res = $dbr->select( 'page', [ 'page_title', 'page_namespace' ] );
 		if ( $res ) {
 			// @codingStandardsIgnoreStart
-			while ( $res && $row = $dbr->fetchRow( $res ) ) {
+			while ( $res && $row = $res->fetchRow() ) {
 				// @codingStandardsIgnoreEnd
 				$cur_title = Title::makeTitleSafe( $row['page_namespace'], $row['page_title'] );
 				if ( $cur_title === null ) {
@@ -175,7 +175,8 @@ class PagePort {
 		if ( $namespace !== '' ) {
 			$namespace .= ':';
 		}
-		if ( MWNamespace::isCapitalized( $title->getNamespace() ) ) {
+		$nsInfo = MediaWikiServices::getInstance()->getNamespaceInfo();
+		if ( $nsInfo->isCapitalized( $title->getNamespace() ) ) {
 			return $namespace . $this->getContLang()->ucfirst( $title->getText() );
 		} else {
 			return $namespace . $title->getText();

--- a/includes/PagePort.php
+++ b/includes/PagePort.php
@@ -57,19 +57,23 @@ class PagePort {
 	public function delete( string $root, string $user = null ): array {
 		if ( $user !== null ) {
 			$user = User::newFromName( $user );
+		} else {
+			$user = RequestContext::getMain()->getUser();
 		}
 		$pages = $this->getPages( $root );
 		foreach ( $pages as $page ) {
 			$title = Title::newFromText( $page['fulltitle'] );
 			$wp = WikiPage::factory( $title );
 			$err = '';
-			$wp->doDeleteArticle(
+			$wp->doDeleteArticleReal(
 				'Deleted by PagePort',
+				$user,
 				false,
 				null,
-				null,
 				$err,
-				$user,
+				null,
+				[],
+				'delete',
 				true
 			);
 		}

--- a/includes/PagePort.php
+++ b/includes/PagePort.php
@@ -34,12 +34,14 @@ class PagePort {
 	public function import( string $root, string $user = null ): array {
 		if ( $user !== null ) {
 			$user = User::newFromName( $user );
+		} else {
+			$user = RequestContext::getMain()->getUser();
 		}
 		$pages = $this->getPages( $root );
 		foreach ( $pages as $page ) {
 			$title = Title::newFromText( $page['fulltitle'] );
 			$wp = WikiPage::factory( $title );
-			$wp->doEditContent( new WikitextContent( $page['content'] ), 'Imported by PagePort', 0, false, $user );
+			$wp->doUserEditContent( new WikitextContent( $page['content'] ), $user, 'Imported by PagePort' );
 		}
 		return $pages;
 	}
@@ -450,7 +452,7 @@ class PagePort {
 				);
 				if ( $res ) {
 					// @codingStandardsIgnoreStart
-					while ( $res && $row = $db->fetchRow( $res ) ) {
+					while ( $res && $row = $res->fetchRow() ) {
 						// @codingStandardsIgnoreEnd
 						if ( !array_key_exists( 'page_title', $row ) ) {
 							continue;
@@ -489,7 +491,7 @@ class PagePort {
 							}
 						}
 					}
-					$db->freeResult( $res );
+					$res->free();
 				}
 			}
 			if ( count( $newcategories ) == 0 ) {

--- a/tests/phpunit/PagePortTest.php
+++ b/tests/phpunit/PagePortTest.php
@@ -265,6 +265,7 @@ class PagePortTest extends MediaWikiIntegrationTestCase {
 
 	/**
 	 * @covers PagePort::import
+	 * @covers PagePort::getAllPages
 	 */
 	public function testImport() {
 		$tempDir = $this->tempdir( 'pageprot_' );
@@ -289,6 +290,10 @@ class PagePortTest extends MediaWikiIntegrationTestCase {
 			$this->assertTrue( $title->exists() );
 			$wp = WikiPage::factory( $title );
 			$this->assertTrue( strlen( $wp->getContent()->getWikitextForTransclusion() ) > 0 );
+		}
+		$allPages = $this->pp->getAllPages();
+		foreach ( $pages as $p ) {
+			$this->assertContains( $p, $allPages );
 		}
 	}
 

--- a/tests/phpunit/PagePortTest.php
+++ b/tests/phpunit/PagePortTest.php
@@ -1,15 +1,13 @@
 <?php
 
-use EnricoStahn\JsonAssert\Assert as JsonAssert;
+use JsonSchema\Validator;
 
 /**
  * @coversDefaultClass PagePort
  * @group Database
  * @group extension-PagePort
  */
-class PagePortTest extends MediaWikiTestCase {
-
-	use JsonAssert;
+class PagePortTest extends MediaWikiIntegrationTestCase {
 
 	/** @var PagePort */
 	private $pp;
@@ -310,6 +308,26 @@ class PagePortTest extends MediaWikiTestCase {
 		if ( is_dir( $tempfile ) ) {
 			return $tempfile;
 		}
+	}
+
+	/**
+	 * MediaWiki's composer merge plugin does not merge dev dependencies, so
+	 * rather than using the assertJsonMatchesSchema() from the
+	 * estahn/phpunit-json-assertions library, re-implement it based on
+	 * justinrainbow/json-schema
+	 */
+	private function assertJsonMatchesSchema( $json, string $schema ) {
+		$validator = new Validator();
+		$validator->validate(
+			$json,
+			(object)['$ref' => 'file://' . realpath( $schema)]
+		);
+		if ( $validator->isValid() ) {
+			$this->addToAssertionCount( 1 );
+			return;
+		}
+		// For a more informative error message
+		$this->assertSame( [], $validator->getErrors() );
 	}
 
 }

--- a/tests/phpunit/PagePortTest.php
+++ b/tests/phpunit/PagePortTest.php
@@ -266,6 +266,7 @@ class PagePortTest extends MediaWikiIntegrationTestCase {
 	/**
 	 * @covers PagePort::import
 	 * @covers PagePort::getAllPages
+	 * @covers PagePort::delete
 	 */
 	public function testImport() {
 		$tempDir = $this->tempdir( 'pageprot_' );
@@ -294,6 +295,11 @@ class PagePortTest extends MediaWikiIntegrationTestCase {
 		$allPages = $this->pp->getAllPages();
 		foreach ( $pages as $p ) {
 			$this->assertContains( $p, $allPages );
+		}
+		$this->pp->delete( $tempDir );
+		$allPages = $this->pp->getAllPages();
+		foreach ( $pages as $p ) {
+			$this->assertNotContains( $p, $allPages );
 		}
 	}
 


### PR DESCRIPTION
* Require MediaWiki 1.39+ and run CI against 1.39

* Drop use of `estahn/phpunit-json-assertions` - while our test action does merge dev dependencies, MediaWiki generally doesn't - instead, implement the validation of the JSON against the schema using the available `justinrainbow/json-schema` library

* Update `PagePortTest` to extend `MediaWikiIntegrationTestCase`; `MediaWikiTestCase` was dropped in 1.38, see `bf56204` in core

* Update `PagePort` to use `WikiPage::doUserEditContent()`, `::doEditContent()` was dropped in 1.39, see `0e39420` in core

* Update `PagePort` to use `IResultWrapper::fetchRow()` and `::free()`; the corresponding methods `::fetchRow()` and `::freeResult()` were removed from the IDatabase interface in 1.39, see `46374a8` in core