### PR TITLE
Test against MediaWiki 1.42 and make pass

### DIFF
--- a/.github/workflows/mediawiki.yml
+++ b/.github/workflows/mediawiki.yml
@@ -44,6 +44,8 @@ jobs:
         include:
           - mw: 'REL1_39'
             php: 7.4
+          - mw: 'REL1_42'
+            php: 8.1
     runs-on: ubuntu-latest
     steps:
       # check out the repository!
@@ -68,7 +70,10 @@ jobs:
       matrix:
         php: [ '7.4', '8.1' ]
         # Deliberately *not* testing against `master`
-        mediawiki: [ REL1_39 ]
+        mediawiki: [ REL1_39, REL1_42 ]
+        exclude:
+          - mediawiki: REL1_42
+            php: '7.4'
     steps:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/composer.json
+++ b/composer.json
@@ -3,10 +3,10 @@
 		"ext-zip": "*"
 	},
 	"require-dev": {
-		"mediawiki/mediawiki-codesniffer": "44.0.0 || 38.0.0",
+		"mediawiki/mediawiki-codesniffer": "44.0.0 || 43.0.0 || 38.0.0",
 		"mediawiki/minus-x": "1.1.0",
 		"php-parallel-lint/php-console-highlighter": "1.0.0 || 0.5",
-		"php-parallel-lint/php-parallel-lint": "1.3.2 || 1.3.1"
+		"php-parallel-lint/php-parallel-lint": "1.4.0 || 1.3.2 || 1.3.1"
 	},
 	"scripts": {
 		"test": [

--- a/includes/ServiceWiring.php
+++ b/includes/ServiceWiring.php
@@ -11,7 +11,8 @@ return [
 		return new PagePort(
 			$services->getContentLanguage(),
 			$services->getDBLoadBalancer(),
-			$services->getNamespaceInfo()
+			$services->getNamespaceInfo(),
+			$services->getWikiPageFactory()
 		);
 	},
 ];

--- a/tests/phpunit/PagePortTest.php
+++ b/tests/phpunit/PagePortTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use JsonSchema\Validator;
+use MediaWiki\Page\WikiPageFactory;
 
 /**
  * @coversDefaultClass PagePort
@@ -11,6 +12,8 @@ class PagePortTest extends MediaWikiIntegrationTestCase {
 
 	/** @var PagePort */
 	private $pp;
+
+	private WikiPageFactory $wikiPageFactory;
 
 	public static function setupBeforeClass(): void {
 		parent::setUpBeforeClass();
@@ -57,6 +60,7 @@ class PagePortTest extends MediaWikiIntegrationTestCase {
 			NS_MEDIAWIKI
 		);
 		$this->pp = PagePort::getInstance();
+		$this->wikiPageFactory = $this->getServiceContainer()->getWikiPageFactory();
 	}
 
 	/**
@@ -308,14 +312,14 @@ class PagePortTest extends MediaWikiIntegrationTestCase {
 		$this->pp->export( $pages, $tempDir );
 		foreach ( $pages as $page ) {
 			$title = Title::newFromText( $page );
-			$wp = WikiPage::factory( $title );
+			$wp = $this->wikiPageFactory->newFromTitle( $title );
 			$wp->doDeleteArticleReal( 'test', $this->getTestUser( 'sysop' )->getUser(), true );
 		}
 		$this->pp->import( $tempDir );
 		foreach ( $pages as $page ) {
 			$title = Title::newFromText( $page );
 			$this->assertTrue( $title->exists() );
-			$wp = WikiPage::factory( $title );
+			$wp = $this->wikiPageFactory->newFromTitle( $title );
 			$content = $wp->getContent();
 			$this->assertTrue( strlen( $content->getWikitextForTransclusion() ) > 0 );
 			if ( $page === 'MediaWiki:Common.css' ) {


### PR DESCRIPTION
- Add REL1_42 to the CI matrix, but only for PHP 8.1

- In composer.json, relax the version constraints for both
php-parallel-lint/php-parallel-lint and mediawiki/mediawiki-codesniffer

- Replaced uses of the removed `WikiPage::factory()` method with a
WikiPageFactory service

- Replace throwing the base `Exception` class, and in the process remove some
unneeded `@throws` tags and inline the single-use `PagePort::checkDirectory()`
method into its caller

SEL-1318