### PR TITLE
Update slash encoding to use `#` rather than `|`

### DIFF
--- a/includes/PagePort.php
+++ b/includes/PagePort.php
@@ -131,13 +131,17 @@ class PagePort {
 				$namespace = basename( $dir );
 				$name = $l;
 
-				if ( strpos( $namespace, '|' ) !== false ) {
-					$namespace = str_replace( '|', '/', $namespace );
-				}
+				$namespace = str_replace( '#', '/', $namespace );
+				# Legacy handling for exports that used | rather than #, which
+				# was changed for windows support in SEL-1609
+				$namespace = str_replace( '|', '/', $namespace );
+
 				$name = str_replace( '.mediawiki', '', $name );
-				if ( strpos( $name, '|' ) !== false ) {
-					$name = str_replace( '|', '/', $name );
-				}
+				$name = str_replace( '#', '/', $name );
+				# Legacy handling for exports that used | rather than #, which
+				# was changed for windows support in SEL-1609
+				$name = str_replace( '|', '/', $name );
+
 				$fulltitle = $namespace . ':' . $name;
 				// Clean up the Main namespace from the title
 				$fulltitle = str_replace( 'Main:', '', $fulltitle );
@@ -228,7 +232,9 @@ class PagePort {
 				continue;
 			}
 			if ( strpos( $namespaceName, '/' ) !== false ) {
-				$namespaceName = str_replace( '/', '|', $namespaceName );
+				// Used to be replaced with a |, now # for windows support,
+				// SEL-1609
+				$namespaceName = str_replace( '/', '#', $namespaceName );
 			}
 			$contentObj = $this->wikiPageFactory->newFromTitle( $title )->getContent();
 			$content = $contentObj->getWikitextForTransclusion();
@@ -236,7 +242,9 @@ class PagePort {
 				mkdir( $root . '/' . $namespaceName );
 			}
 			if ( strpos( $filename, '/' ) !== false ) {
-				$filename = str_replace( '/', '|', $filename );
+				// Used to be replaced with a |, now # for windows support,
+				// SEL-1609
+				$filename = str_replace( '/', '#', $filename );
 			}
 			$targetFileName = $root . '/' . $namespaceName . '/' . $filename;
 			if ( $contentObj->getModel() === CONTENT_MODEL_WIKITEXT ) {
@@ -342,7 +350,7 @@ class PagePort {
 				$packageName => [
 					"globalID" => str_replace( ' ', '.', $packageName ),
 					"description" => $packageDesc,
-					"version" => $version ?: '0.1',
+					"version" => $version ?: '0.2',
 					"pages" => [],
 					"requiredExtensions" => []
 				]
@@ -352,7 +360,7 @@ class PagePort {
 		foreach ( $pages as $page ) {
 			$title = Title::newFromText( $page );
 			$name = $title->getText();
-			$escapedName = str_replace( '/', '|', $name );
+			$escapedName = str_replace( '/', '#', $name );
 			$namespace = $this->getNamespaceByValue( $title->getNamespace() );
 			// PagePort can't handle deprecated NS_IMAGE
 			if ( $namespace === "NS_IMAGE" ) {


### PR DESCRIPTION
When a subpage is exported, or the namespace of an exported page contains a `/`, PagePort previously put the content of the page in a file where the `/` was replaced with a `|`, so that extra slashes in page names or namespaces would not result in increasing levels of sub directories in the package output.

The `|` was presumably chosen to ensure that the encoded name would not conflict with any real page names, since `|` is not support for page titles in MediaWiki. However, `|` is also not supported in file names on Windows machines. Instead, encode the `/` with a `#`, which is likewise not allowed in MediaWiki page titles, but *is* allowed in Windows file names.

While the behavior for new exports is to use `#`, any existing export that uses `|` can still be imported, and a test case is added to verify that backwards compatibility is not broken.

The default version of packages exported is now 0.2 rather than 0.1 to allow packages without explicit versions to be identified as coming after this fix.

Additionally, split `PagePortTest::testImport()` to avoid deleting the pages after exporting; it seems that PHPUnit only runs `setUp()` *once* for each test method, even if a test method uses a data provider. Thus, the deletion at the end of the first execution of `testImport()` was breaking the export of the same pages in the second execution that was added. Instead, add a separate `PagePortTest::testDelete()` test.

SEL-1609